### PR TITLE
Update dataTables.dateTime.js to use classPrefixed empty class

### DIFF
--- a/js/dataTables.dateTime.js
+++ b/js/dataTables.dateTime.js
@@ -860,12 +860,12 @@ $.extend(DateTime.prototype, {
 	 * @return {string}     HTML cell
 	 */
 	_htmlDay: function (day) {
+		var classPrefix = this.c.classPrefix;
 		if (day.empty) {
-			return '<td class="empty"></td>';
+			return '<td class="' + classPrefix + '-empty"></td>';
 		}
 
 		var classes = ['selectable'];
-		var classPrefix = this.c.classPrefix;
 
 		if (day.disabled) {
 			classes.push('disabled');


### PR DESCRIPTION
Fixes #14 
<img width="1910" alt="image" src="https://github.com/user-attachments/assets/b327e36b-77b8-42df-851a-5417db28442e" />
