### PR TITLE
Fix typo in dataTables.dateTime.d.ts

### DIFF
--- a/js/dataTables.dateTime.d.ts
+++ b/js/dataTables.dateTime.d.ts
@@ -62,6 +62,6 @@ interface JQuery {
 // Also attached to DataTables object
 declare module 'datatables.net-datetime' {
 	interface ApiStatic {
-		DataTime: DateTime;
+		DateTime: DateTime;
 	}
 }


### PR DESCRIPTION
`DateTime` was accidentally spelled `DataTime` in the module declaration.